### PR TITLE
Catch missing environment variables when creating environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ bootstrap:
 - ./extra-config.sh
 
 # An array of environment variables. Anything with a $ will be evaluated against
-# the current set of exported variables being used by the current session.
+# the current set of exported variables being used by the current session. If
+# any of them evaluate to nothing, envctl will fail to create the environment.
 variables:
   FOO: bar
   SECRET: $SECRET

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ bootstrap:
 # An array of environment variables. Anything with a $ will be evaluated against
 # the current set of exported variables being used by the current session.
 variables:
-- FOO=bar
-- SECRET=$SECRET
+  FOO: bar
+  SECRET: $SECRET
 ```
 
 ## Contributing Guide

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -177,6 +177,10 @@ func parseVariables(cfg config.Opts) ([]string, error) {
 			v = os.Getenv(v[1:])
 		}
 
+		if v == "" {
+			return []string{}, fmt.Errorf("missing variable %v", k)
+		}
+
 		envs = append(envs, fmt.Sprintf("%v=%v", k, v))
 	}
 

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -193,6 +193,7 @@ func TestCreateWithDynamicVariables(got *testing.T) {
 	ctl := newMockCtl(nil)
 
 	os.Setenv("ENVCTL_TESTING", "FOO")
+	defer os.Setenv("ENVCTL_TESTING", "")
 
 	cmd := newCreateCmd(ctl, s, cfg)
 
@@ -211,6 +212,28 @@ func TestCreateWithDynamicVariables(got *testing.T) {
 	expected := "ENVCTL_TESTING=FOO"
 	if s.env.Container.Envs[0] != expected {
 		t.Fatal("variables", expected, s.env.Container.Envs[0])
+	}
+}
+
+func TestParseMissingVariables(got *testing.T) {
+	t := test_pkg.NewT(got)
+
+	opts := config.Opts{
+		Image: "test",
+		Shell: "/foo/sh",
+		Mount: "/foo/mnt",
+		Variables: map[string]string{
+			"ENVCTL_TESTING": "$ENVCTL_TESTING",
+		},
+	}
+
+	envs, err := parseVariables(opts)
+	if err == nil {
+		t.Fatal("error parsing variables", "missing variable ENVCTL_TESTING", err)
+	}
+
+	if len(envs) != 0 {
+		t.Fatal("number of parsed missing variables", 0, len(envs))
 	}
 }
 


### PR DESCRIPTION
This was one of `envctl`'s original functions, back when it was a series of shell scripts in our repos.

Finally, it's being added in.

Resolves #8 