### PR TITLE
Allow disabling of image caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ The configuration takes the following format:
 # Required - the base container image for the environment
 image: ubuntu:latest
 
+# Specifies whether the base image should be cached. Defaults to true.
+cache_image: false
+
 # Required - the shell to use when logged in
 shell: /bin/bash
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -77,10 +77,11 @@ To use it, run "envctl login", or destroy it with "envctl destroy".`
 				Source:      pwd,
 				Destination: mount,
 			},
-			Envs: envs,
+			Envs:    envs,
+			NoCache: !(*cfg.CacheImage),
 		}
 
-		fmt.Println("creating your environment... ")
+		fmt.Println("creating your environment...")
 
 		newMeta, err := ctl.Create(meta)
 		if err != nil {
@@ -90,7 +91,7 @@ To use it, run "envctl login", or destroy it with "envctl destroy".`
 
 		rawcmds := cfg.Bootstrap
 		if len(rawcmds) > 0 {
-			fmt.Println("running bootstrap steps... ")
+			fmt.Println("running bootstrap steps...")
 
 			script := &bytes.Buffer{}
 			for _, rawcmd := range rawcmds {
@@ -134,7 +135,7 @@ To use it, run "envctl login", or destroy it with "envctl destroy".`
 			}
 		}
 
-		fmt.Println("saving environment... ")
+		fmt.Println("saving environment...")
 		err = s.Create(db.Environment{
 			Status:    db.StatusReady,
 			Container: newMeta,

--- a/cmd/mocks_for_test.go
+++ b/cmd/mocks_for_test.go
@@ -94,5 +94,9 @@ type memConfig struct {
 }
 
 func (c memConfig) Load() (config.Opts, error) {
+	if c.opts.CacheImage == nil {
+		c.opts.CacheImage = config.CacheImage
+	}
+
 	return c.opts, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,7 +2,11 @@ package config
 
 // Opts is what tells envctl what the environment looks like.
 type Opts struct {
-	Image     string            `yaml:"image"`
+	Image string `yaml:"image"`
+	// The default for this field is true, so `nil`` needs to be discernable
+	// from the default `false` value.
+	CacheImage *bool `yaml:"cache_image,omitempty"`
+
 	Shell     string            `yaml:"shell"`
 	Mount     string            `yaml:"mount,omitempty"`
 	Variables map[string]string `yaml:"variables,omitempty"`

--- a/internal/config/yaml.go
+++ b/internal/config/yaml.go
@@ -7,6 +7,15 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
+var t = true
+var f = false
+
+// CacheImage is a helper for specifying whether an image should be cached.
+var CacheImage = &t
+
+// NoCacheImage is a helper for specifying whether an image shouldn't be cached.
+var NoCacheImage = &f
+
 // YAML is a Loader for a YAML configuration file.
 type YAML struct {
 	Path string
@@ -33,6 +42,10 @@ func (c YAML) Load() (Opts, error) {
 
 	if cfg.Shell == "" {
 		return Opts{}, errors.New("missing shell")
+	}
+
+	if cfg.CacheImage == nil {
+		cfg.CacheImage = CacheImage
 	}
 
 	return cfg, nil

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -13,6 +13,7 @@ type Metadata struct {
 	Shell     string   `json:"shell"`
 	Mount     Mount    `json:"mount"`
 	Envs      []string `json:"envs"`
+	NoCache   bool     `json:"no_cache"`
 }
 
 // Mount is directory on the host paired with a volume mount point.

--- a/pkg/container/docker/create.go
+++ b/pkg/container/docker/create.go
@@ -78,7 +78,8 @@ func (c *Controller) buildImage(m container.Metadata) (string, error) {
 
 	name := fmt.Sprintf("%v:%v", m.BaseName, uuid.New().String())
 	bldopts := types.ImageBuildOptions{
-		Tags: []string{name},
+		Tags:    []string{name},
+		NoCache: m.NoCache,
 	}
 
 	resp, err := c.client.ImageBuild(context.Background(), buildContext, bldopts)


### PR DESCRIPTION
Some use cases require the absolute latest version of an image to be
used at all times.

This inverts the logic from what Docker uses. Instead of specifing
whether *not* to cache the image, the configuration specifies whether
the image *should* be cached at all.

Resolves #26 