### PR TITLE
Add port bindings to environments

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -80,6 +80,7 @@ To use it, run "envctl login", or destroy it with "envctl destroy".`
 			Envs:    envs,
 			NoCache: !(*cfg.CacheImage),
 			User:    cfg.User,
+			Ports:   cfg.Ports,
 		}
 
 		fmt.Println("creating your environment...")

--- a/envctl.yaml
+++ b/envctl.yaml
@@ -13,3 +13,7 @@ bootstrap:
 - echo 'INIT' > /foo.txt
 - echo 'MOAR INIT' >> /foo.txt
 - sleep 5
+
+ports:
+  tcp:
+  - 4567

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,9 +12,18 @@ type Opts struct {
 	Mount     string            `yaml:"mount,omitempty"`
 	Variables map[string]string `yaml:"variables,omitempty"`
 	Bootstrap []string          `yaml:"bootstrap,omitempty"`
+
+	// Exposing the host network isn't a cross-platform solution, so the
+	// upfront requirement is to expose any ports that the user needs. The ports
+	// are to be mapped directly from container to host so that whatever is
+	// exposed in the container is the port that's accessed on the host.
+	Ports L3Ports `yaml:"ports,omitempty"`
 }
 
 // Loader is anything that can load a configuration file.
 type Loader interface {
 	Load() (Opts, error)
 }
+
+// L3Ports are mappings between a layer 3 protocol like TCP and a port number.
+type L3Ports map[string][]int

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -6,15 +6,16 @@ import "fmt"
 // everything that a consumer of this package needs to know about containers
 // being managed.
 type Metadata struct {
-	ID        string   `json:"id"`
-	ImageID   string   `json:"image_id"`
-	BaseName  string   `json:"base_name"`
-	BaseImage string   `json:"base_image"`
-	Shell     string   `json:"shell"`
-	Mount     Mount    `json:"mount"`
-	Envs      []string `json:"envs"`
-	NoCache   bool     `json:"no_cache"`
-	User      string   `json:"user"`
+	ID        string           `json:"id"`
+	ImageID   string           `json:"image_id"`
+	BaseName  string           `json:"base_name"`
+	BaseImage string           `json:"base_image"`
+	Shell     string           `json:"shell"`
+	Mount     Mount            `json:"mount"`
+	Envs      []string         `json:"envs"`
+	NoCache   bool             `json:"no_cache"`
+	User      string           `json:"user"`
+	Ports     map[string][]int `json:"ports"`
 }
 
 // Mount is directory on the host paired with a volume mount point.


### PR DESCRIPTION
Sometimes users may want to run an app inside the environment, so they
can use their tooling to do so. In this case, they'll want to be able to
access the app on some exposed port.

This allows binding ports for different protocols by adding a key to the
config file that specifies them, grouped by protocol.

This resolves #31.